### PR TITLE
Added more logic to help with round robin-ing the load

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "postgres-queue",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "A PostGres backed request-response queue for node.",
   "main": "index.js",
   "directories": {

--- a/test/index.js
+++ b/test/index.js
@@ -9,7 +9,7 @@ beforeEach(function(done) {
 
   Consumer = new comrade.Consumer('postgres://localhost/postgres', function(err, client) {
     Consumer.deleteAllJobs(function(err, results) {
-      iAmDone()
+      iAmDone();
     });
   }, 0);
 
@@ -75,7 +75,7 @@ describe('Comrade job processor', function() {
 
     Producer.createJob('default', { timeout: 0 })
     .then(function(results) {
-      done('This should have thrown an error.')
+      done('This should have thrown an error.');
     })
     .catch(function(err) {
       expect(err).to.not.be.a('null');
@@ -119,10 +119,10 @@ describe('Comrade job processor', function() {
       });
     });
 
-    var Consumer1 = new comrade.Consumer('postgres://localhost/postgres', allConnected, 1);
-    var Consumer2 = new comrade.Consumer('postgres://localhost/postgres', allConnected, 2);
-    var Consumer3 = new comrade.Consumer('postgres://localhost/postgres', allConnected, 3);
-    var Consumer4 = new comrade.Consumer('postgres://localhost/postgres', allConnected, 4);
+    var Consumer1 = new comrade.Consumer('postgres://localhost/postgres', allConnected, 1, 0, 4);
+    var Consumer2 = new comrade.Consumer('postgres://localhost/postgres', allConnected, 2, 0, 4);
+    var Consumer3 = new comrade.Consumer('postgres://localhost/postgres', allConnected, 3, 0, 4);
+    var Consumer4 = new comrade.Consumer('postgres://localhost/postgres', allConnected, 4, 0, 4);
   });
 
   it('Work done by different instances on different queues', function(done) {

--- a/test/index.js
+++ b/test/index.js
@@ -120,9 +120,9 @@ describe('Comrade job processor', function() {
     });
 
     var Consumer1 = new comrade.Consumer('postgres://localhost/postgres', allConnected, 1, 0, 4);
-    var Consumer2 = new comrade.Consumer('postgres://localhost/postgres', allConnected, 2, 0, 4);
-    var Consumer3 = new comrade.Consumer('postgres://localhost/postgres', allConnected, 3, 0, 4);
-    var Consumer4 = new comrade.Consumer('postgres://localhost/postgres', allConnected, 4, 0, 4);
+    var Consumer2 = new comrade.Consumer('postgres://localhost/postgres', allConnected, 2, 1, 4);
+    var Consumer3 = new comrade.Consumer('postgres://localhost/postgres', allConnected, 3, 2, 4);
+    var Consumer4 = new comrade.Consumer('postgres://localhost/postgres', allConnected, 4, 3, 4);
   });
 
   it('Work done by different instances on different queues', function(done) {


### PR DESCRIPTION
You can pass in two extra variables:

Cyclic Offset
Total Consumers

What it does it makes every consumer wait X number of milliseconds
before attempting to place a lock on the job. If there are 4 consumers,
and we are process 0, with an offset of 0, we will wait a rolling number
of milliseconds like so:

0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3

This is to attempt to make the load more balanced between all workers as
the first 2 or 3 workers that start listening usually grab most of the
work that comes in.

Cyclic offset tell the process where to start in the delays. If you have
4 processes, then you use 0, 1, 2, 3 across all of them.
